### PR TITLE
OSASINFRA-3499: revert hack for MultiZone

### DIFF
--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -348,8 +348,7 @@ func (c *DeploymentConfig) setLocation(hcp *hyperv1.HostedControlPlane, multiZon
 	c.setColocation(hcp)
 	// TODO (alberto): pass labels with deployment hash and set this unconditionally so we don't skew setup.
 	if c.Replicas > 1 {
-		// OpenStack HACK: need a way to conditionally disable this
-		//c.setMultizoneSpread(multiZoneSpreadLabels)
+		c.setMultizoneSpread(multiZoneSpreadLabels)
 		c.setNodeSpread(multiZoneSpreadLabels)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

HA can't work right now because OSP clouds don't always have multiple AZ and HCP sets the topology zone label for pods in restrictive mode.

So for the dev preview we will restrict the install to SingleReplica.
