### PR TITLE
OpenStack: fix conversion test

### DIFF
--- a/hypershift-operator/conversion/fuzz.go
+++ b/hypershift-operator/conversion/fuzz.go
@@ -55,6 +55,7 @@ type FuzzTestFuncInput struct {
 
 	Hub              runtime.Object
 	HubAfterMutation func(runtime.Object)
+	HubAfterFuzz     func(runtime.Object)
 
 	Spoke                      runtime.Object
 	SpokeAfterMutation         func(runtime.Object)
@@ -106,6 +107,10 @@ func FuzzTestFunc(input FuzzTestFuncInput) func(*testing.T) {
 				// Create the hub and fuzz it
 				hubBefore := input.Hub.DeepCopyObject()
 				fuzzer.Fuzz(hubBefore)
+
+				if input.HubAfterFuzz != nil {
+					input.HubAfterFuzz(hubBefore)
+				}
 
 				// First convert hub to spoke
 				dstCopy := input.Spoke.DeepCopyObject()


### PR DESCRIPTION
When converting a fuzzed object from beta1 to alpha1 and then back to beta1, the resulting object will be different from the first one because in alpha there is no support for OpenStack. This commit fixes the issue by enforcing empty OpenStack platform on the fuzzed beta1 object.